### PR TITLE
[stable/janusgraph] bump k8s api to stable

### DIFF
--- a/stable/janusgraph/Chart.yaml
+++ b/stable/janusgraph/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: Open source, scalable graph database.
 name: janusgraph
-version: 0.2.1
+version: 0.2.2
 home: http://janusgraph.org
 icon: https://raw.githubusercontent.com/JanusGraph/janusgraph/master/janusgraph.png
 sources:

--- a/stable/janusgraph/templates/deployment.yaml
+++ b/stable/janusgraph/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "janusgraph.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:
In k8s >v1.9 the "apps/v1beta2" API was superseeded by "apps/v1", and deprecated.
For kubernetes versions later than 1.15 the old API does not work anymore at all. This PR is making janusgraph run again.

#### Which issue this PR fixes
  - fixes #22877

#### Special notes for your reviewer:
I don't expect this to get merged, as the janusgraph chart is currently unmaintained. This is mostly for reference, in case anyone wants to fix it.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
